### PR TITLE
Fix nested data deserialization in vvvvQuery arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,6 @@ MigrationBackup/
 /lib/net472/
 /lib/
 */lib/
+
+# Visual Studio launch settings (user-specific)
+**/Properties/launchSettings.json

--- a/VL.CEF/src/WebBrowser.Handlers.cs
+++ b/VL.CEF/src/WebBrowser.Handlers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xilium.CefGlue;
 using System.Diagnostics;
 using Stride.Core.Mathematics;
@@ -383,7 +383,7 @@ namespace VL.CEF
                     {
                         var x = new SpreadBuilder<object>(list.Count);
                         for (int i = 0; i < list.Count; i++)
-                            x.Add(ToValue(list.GetValue(i)));
+                            x.Add(ToObject(list.GetValue(i)));
                         return x.ToSpread();
                     }
                 }


### PR DESCRIPTION
## Summary

- Fix incorrect method call in `ToSpread` method: `ToValue` → `ToObject`
- This fixes deserialization of nested data structures (lists, dictionaries) in vvvvQuery arguments

## Details

- Updated `ToSpread` method in `WebBrowser.Handlers.cs` to use `ToObject` instead of `ToValue` when converting list items
- This ensures proper recursive deserialization of nested data structures
- Added `launchSettings.json` to `.gitignore` to exclude user-specific development files

## Changes

- `VL.CEF/src/WebBrowser.Handlers.cs`: Fixed method call in line 386
- `.gitignore`: Added exclusion for `**/Properties/launchSettings.json`

## Testing

- Tested on Windows 10 with .NET 8
- Verified that nested lists and dictionaries are properly deserialized when passed as arguments to vvvvQuery handlers
- Confirmed that the fix resolves the issue where nested data structures were not being correctly parsed

## Related

This fix addresses the issue where nested data structures in vvvvQuery arguments were not being properly deserialized, causing incorrect data handling in query handlers.